### PR TITLE
Hotfix: Fix workflow syntax error by using RUNNER_TEMP environment variable

### DIFF
--- a/.github/workflows/fitbit-pipeline.yml
+++ b/.github/workflows/fitbit-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
   run-pipeline:
     runs-on: ubuntu-latest
     env:
-      GOOGLE_APPLICATION_CREDENTIALS: $HOME/sa_key.json
+      GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa_key.json
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/fitbit-pipeline.yml
+++ b/.github/workflows/fitbit-pipeline.yml
@@ -13,9 +13,11 @@ on:
 jobs:
   run-pipeline:
     runs-on: ubuntu-latest
-    env:
-      GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa_key.json
     steps:
+      - name: Set environment variables
+        run: |
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa_key.json" >> $GITHUB_ENV
+          
       - name: Checkout code
         uses: actions/checkout@v4
         

--- a/.github/workflows/hubspot-pipeline.yml
+++ b/.github/workflows/hubspot-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
   run-pipeline:
     runs-on: ubuntu-latest
     env:
-      GOOGLE_APPLICATION_CREDENTIALS: $HOME/sa_key.json
+      GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa_key.json
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/hubspot-pipeline.yml
+++ b/.github/workflows/hubspot-pipeline.yml
@@ -13,9 +13,11 @@ on:
 jobs:
   run-pipeline:
     runs-on: ubuntu-latest
-    env:
-      GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa_key.json
     steps:
+      - name: Set environment variables
+        run: |
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa_key.json" >> $GITHUB_ENV
+          
       - name: Checkout code
         uses: actions/checkout@v4
         

--- a/.github/workflows/notion-pipeline.yml
+++ b/.github/workflows/notion-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
   run-pipeline:
     runs-on: ubuntu-latest
     env:
-      GOOGLE_APPLICATION_CREDENTIALS: $HOME/sa_key.json
+      GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa_key.json
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/notion-pipeline.yml
+++ b/.github/workflows/notion-pipeline.yml
@@ -13,9 +13,11 @@ on:
 jobs:
   run-pipeline:
     runs-on: ubuntu-latest
-    env:
-      GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa_key.json
     steps:
+      - name: Set environment variables
+        run: |
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa_key.json" >> $GITHUB_ENV
+          
       - name: Checkout code
         uses: actions/checkout@v4
         

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -18,7 +18,7 @@ jobs:
   test-pipelines:
     runs-on: ubuntu-latest
     env:
-      GOOGLE_APPLICATION_CREDENTIALS: $HOME/sa_key.json
+      GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa_key.json
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pipeline-tests.yml
+++ b/.github/workflows/pipeline-tests.yml
@@ -17,9 +17,11 @@ on:
 jobs:
   test-pipelines:
     runs-on: ubuntu-latest
-    env:
-      GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa_key.json
     steps:
+      - name: Set environment variables
+        run: |
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$RUNNER_TEMP/sa_key.json" >> $GITHUB_ENV
+          
       - name: Checkout code
         uses: actions/checkout@v4
         


### PR DESCRIPTION
This hotfix resolves a syntax error in GitHub Actions workflows caused by using an invalid `runner.temp` context.

## Changes
- Replace invalid `${{ runner.temp }}` context with proper `$RUNNER_TEMP` environment variable
- Add "Set environment variables" step to all workflow files to set GOOGLE_APPLICATION_CREDENTIALS
- Ensures compatibility across all GitHub Actions runners
- Fixes syntax error that was preventing workflows from running

## Updated workflows
- fitbit-pipeline.yml
- hubspot-pipeline.yml  
- notion-pipeline.yml
- pipeline-tests.yml

## Issue
The workflows were failing with: `Unrecognized named-value: 'runner'. Located at position 1 within expression: runner.temp`

## Solution
Now uses `$RUNNER_TEMP` environment variable in an early step to set the service account key path, making it available to all subsequent steps via `$GITHUB_ENV`.
