### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/refresh-notion.yml
+++ b/.github/workflows/refresh-notion.yml
@@ -10,6 +10,9 @@ on:
         default: 'false'
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   run-pipeline:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/michaelconan/personal-reporting-pipelines/security/code-scanning/4](https://github.com/michaelconan/personal-reporting-pipelines/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the workflow to restrict the scope of the `GITHUB_TOKEN` used by this job. The least privilege needed for this workflow is typically `contents: read`, as it does not push code or modify pull requests or issues. The `run`, `checkout`, and `upload-artifact` actions only require read access to repository contents. Therefore, insert a `permissions:` section at the top-level of the workflow (after `name:` and `on:`), setting `contents: read`. No other changes are necessary. The edit should go after the `name` and `on` blocks, before `jobs:` for workflow-global effect.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
